### PR TITLE
[codex] Set DDP header byte

### DIFF
--- a/test_pixel_writer.py
+++ b/test_pixel_writer.py
@@ -83,7 +83,8 @@ def test_ddp_packet_structure():
         
         header = packet_data[:10]
         print(f"    ✓ Header: {header.hex()}")
-        
+        assert header[1] == 0x0B, "Second DDP header byte should be 0x0B"
+
         # Verify data portion contains our RGB data
         data_portion = packet_data[10:]
         expected_data = byte_data

--- a/wledcast/wled/pixel_writer.py
+++ b/wledcast/wled/pixel_writer.py
@@ -22,7 +22,7 @@ class PixelWriter:
     def _create_ddp_packet(self, data, data_offset, is_last_packet=False):
         header = bytearray(10)
         header[0] = 0b01000000 | (0b00000001 if is_last_packet else 0)
-        header[1] = self.sequence_id
+        header[1] = 0x0B
         header[2] = 0x01  # Data type set to 01
         header[3] = self.DDP_DESTINATION_ID
         header[4:8] = data_offset.to_bytes(4, byteorder="big")


### PR DESCRIPTION
## Summary
- set the second DDP header byte to 0x0B when creating pixel packets
- add a packet-structure assertion covering the fixed header byte

## Validation
- ./venv/Scripts/python.exe test_pixel_writer.py

## Notes
- installed requirements into the existing venv so validation could run there